### PR TITLE
Fix - Data table pagination when the page does not have any record

### DIFF
--- a/src/Pagination.vue
+++ b/src/Pagination.vue
@@ -43,6 +43,7 @@ export default {
     dspBtns () {
       const n = this.totalPage
       const i = this.curPage
+      this.checkPageCounts()
 
       /* eslint-disable */
       if (n <= 9) return ((n) => {
@@ -57,6 +58,11 @@ export default {
     }
   },
   methods: {
+    checkPageCounts() {
+      if (this.curPage > this.totalPage && (this.curPage !== 1)) {
+        this.handleClick(this.curPage - 1)
+      }
+    },
     handleClick (n) {
       this.query.offset = (n - 1) * +this.query.limit
     },

--- a/src/Pagination.vue
+++ b/src/Pagination.vue
@@ -43,6 +43,7 @@ export default {
     dspBtns () {
       const n = this.totalPage
       const i = this.curPage
+
       this.checkPageCounts()
 
       /* eslint-disable */


### PR DESCRIPTION
 - If a page of data table does not have any record, related data table pagination button disappears but page stay with No Data message. In order to synchronize pages and pagination buttons, I added condition which checks total page and current pages.